### PR TITLE
feat: 팀원 블로그 웹뷰로 보는 기능 추가

### DIFF
--- a/TeamIntroApp/Base.lproj/Main.storyboard
+++ b/TeamIntroApp/Base.lproj/Main.storyboard
@@ -1,24 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="xXg-8K-D3V">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="TeamIntroApp" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ynh-gv-OXi">
+                                <rect key="frame" x="84" y="732" width="226" height="64"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="filled" title="(임시버튼) 블로그 웹뷰용 버튼"/>
+                                <connections>
+                                    <action selector="blogButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZJA-JL-sXF"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <navigationItem key="navigationItem" id="haH-Il-Zso"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="959.5419847328244" y="-34.507042253521128"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="ta1-eg-5fk">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="xXg-8K-D3V" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="0Mj-4c-qnk">
+                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="9Vi-iQ-2MM"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qrp-Ju-ZdJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="32.824427480916029" y="-34.507042253521128"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/TeamIntroApp/Model/TeamMember.swift
+++ b/TeamIntroApp/Model/TeamMember.swift
@@ -1,0 +1,17 @@
+//
+//  TeamMember.swift
+//  TeamIntroApp
+//
+//  Created by ksy on 5/20/25.
+//
+
+import Foundation
+
+struct TeamMember {
+    let name: String
+    let mbti: String
+    let description: String
+    let strengths: [String]
+    let collaborationStyle: String
+    let blogURL: URL
+} 

--- a/TeamIntroApp/Temp/TempForBlogMemberListViewController.swift
+++ b/TeamIntroApp/Temp/TempForBlogMemberListViewController.swift
@@ -1,0 +1,125 @@
+import UIKit
+import WebKit
+
+class BlogWebViewController: UIViewController {
+    private let webView: WKWebView = {
+        let webView = WKWebView()
+        return webView
+    }()
+    
+    private let url: URL
+    
+    init(url: URL) {
+        self.url = url
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        setupNavigationBar()
+        loadWebView()
+    }
+    
+    private func setupNavigationBar() {
+        let openInSafariButton = UIBarButtonItem(
+            image: UIImage(systemName: "safari"),
+            style: .plain,
+            target: self,
+            action: #selector(openInSafari)
+        )
+        navigationItem.rightBarButtonItem = openInSafariButton
+    }
+    
+    @objc private func openInSafari() {
+        if UIApplication.shared.canOpenURL(url) {
+            UIApplication.shared.open(url)
+        }
+    }
+    
+    private func setupUI() {
+        view.backgroundColor = .white
+        view.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+    
+    private func loadWebView() {
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+}
+
+class TempForBlogMemberListViewController: UIViewController {
+    private let tableView: UITableView = {
+        let table = UITableView()
+        table.register(UITableViewCell.self, forCellReuseIdentifier: "MemberCell")
+        return table
+    }()
+    
+    private let members: [TeamMember] = [
+        TeamMember(name: "박주하", mbti: "", description: "", strengths: [], collaborationStyle: "", blogURL: URL(string: "https://velog.io/@juha")!),
+        TeamMember(name: "김우성", mbti: "", description: "", strengths: [], collaborationStyle: "", blogURL: URL(string: "https://velog.io/@housedone")!),
+        TeamMember(name: "이서린", mbti: "", description: "", strengths: [], collaborationStyle: "", blogURL: URL(string: "https://velog.io/@seorin")!),
+        TeamMember(name: "김성연", mbti: "", description: "", strengths: [], collaborationStyle: "", blogURL: URL(string: "https://velog.io/@greenocean")!),
+        TeamMember(name: "박범근", mbti: "", description: "", strengths: [], collaborationStyle: "", blogURL: URL(string: "https://velog.io/@luca__tuna")!)
+    ]
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+    }
+    
+    private func setupUI() {
+        view.backgroundColor = .white
+        title = "(임시화면) 팀원 리스트"
+        
+        view.addSubview(tableView)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        
+        tableView.delegate = self
+        tableView.dataSource = self
+    }
+}
+
+extension TempForBlogMemberListViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return members.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "MemberCell", for: indexPath)
+        let member = members[indexPath.row]
+        
+        var content = cell.defaultContentConfiguration()
+        content.text = member.name
+        content.secondaryText = "블로그 보기 → \(member.blogURL.absoluteString)"
+        content.secondaryTextProperties.color = .systemBlue
+        cell.contentConfiguration = content
+        cell.accessoryType = .disclosureIndicator
+        
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        let member = members[indexPath.row]
+        let webViewController = BlogWebViewController(url: member.blogURL)
+        navigationController?.pushViewController(webViewController, animated: true)
+    }
+} 

--- a/TeamIntroApp/ViewController.swift
+++ b/TeamIntroApp/ViewController.swift
@@ -13,7 +13,11 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
-
+    
+    @IBAction func blogButtonTapped(_ sender: UIButton) {
+        let memberListVC = TempForBlogMemberListViewController()
+        self.navigationController?.pushViewController(memberListVC, animated: true)
+    }
 
 }
 


### PR DESCRIPTION
주요 변경사항
- 팀원 리스트에서 각 팀원의 블로그를 앱 내 웹뷰로 볼 수 있는 기능 추가
- 팀원 정보를 관리하는 TeamMember 모델을 Model 폴더로 분리
- 웹뷰 화면에서 우측 상단에 외부 브라우저로 열기(Safari) 버튼 추가